### PR TITLE
Add CustomName to generated chest UUID to solve caching problem

### DIFF
--- a/src/main/java/traben/entity_texture_features/mixin/client/entity/blockEntity/MixinChestBlockEntityRenderer.java
+++ b/src/main/java/traben/entity_texture_features/mixin/client/entity/blockEntity/MixinChestBlockEntityRenderer.java
@@ -20,6 +20,7 @@ import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.decoration.ArmorStandEntity;
 import net.minecraft.util.Identifier;
+import net.minecraft.util.Nameable;
 import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -96,12 +97,16 @@ public abstract class MixinChestBlockEntityRenderer<T extends BlockEntity & Ches
         if (ETFConfigData.enableCustomTextures) {
             etf$chestStandInDummy = new ArmorStandEntity(EntityType.ARMOR_STAND, MinecraftClient.getInstance().world);
             etf$chestStandInDummy.setPos(entity.getPos().getX(), entity.getPos().getY(), entity.getPos().getZ());
-            if (entity instanceof ChestBlockEntity) {
-                etf$chestStandInDummy.setCustomName(((ChestBlockEntity) entity).getCustomName());
-                etf$chestStandInDummy.setCustomNameVisible(((ChestBlockEntity) entity).hasCustomName());
+            String identifier = entity.getPos().toString();
+            if (entity instanceof Nameable nameable) {
+                etf$chestStandInDummy.setCustomName(nameable.getCustomName());
+                etf$chestStandInDummy.setCustomNameVisible(nameable.hasCustomName());
+                if(nameable.hasCustomName()) {
+                    identifier += nameable.getCustomName().asString();
+                }
             }
             //chests don't have uuid so set UUID from something repeatable I chose from block pos
-            etf$chestStandInDummy.setUuid(UUID.nameUUIDFromBytes(entity.getPos().toString().getBytes()));
+            etf$chestStandInDummy.setUuid(UUID.nameUUIDFromBytes(identifier.getBytes()));
         }
     }
 


### PR DESCRIPTION
When placing down a chest, with or without a custom name, the UUID used for caching the custom texture is only calculated using the BlockPos.
Breaking the chest a placing a differently named chest then still shows the texture of the intital chest.
To solve this, the CustomName of the chest has been added to the bytes used to generate the UUID